### PR TITLE
fix: crashed on Lumen framework

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -23,7 +23,7 @@ class Normalizer implements CastsAttributes
     public function __construct(string $class)
     {
         $this->class = $class;
-        $this->serializer = resolve(SymfonySerializer::class);
+        $this->serializer = app(SymfonySerializer::class);
     }
 
     /**

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -19,7 +19,7 @@ class Serializer implements CastsAttributes
     public function __construct(string $class)
     {
         $this->class = $class;
-        $this->serializer = resolve(SymfonySerializer::class);
+        $this->serializer = app(SymfonySerializer::class);
     }
 
     /**


### PR DESCRIPTION
It crashes on Lumen only due to usage of `resolve()` helper that is not available in Lumen. `app()` can be used instead so it will work on both Lumen and Laravel just fine. Other than that for now I did not saw other compatibility issues, so Lumen could by officially supported by this package :)



