### PR TITLE
Support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^8.0|^9.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
         "morrislaptop/symfony-custom-normalizers": "^0.4|^0.5",
         "symfony/property-access": "^5.2|^6.0",
         "symfony/property-info": "^5.2|^6.0",


### PR DESCRIPTION
Laravel 10 require illuminate/* libs version 10, but this package support max 9 version of illuminate/contracts